### PR TITLE
feat(ci): Jenkins 파이프라인에 Discord 빌드 알림 추가

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,10 +81,100 @@ pipeline {
 
     post {
         success {
-            echo "Successfully deployed ${IMAGE_NAME}:${env.IMAGE_TAG} to ${env.TARGET_ENV}"
+            script {
+                notifyDiscord('success')
+            }
         }
         failure {
-            echo "Pipeline failed for ${IMAGE_NAME}"
+            script {
+                notifyDiscord('failure')
+            }
         }
+        aborted {
+            script {
+                notifyDiscord('aborted')
+            }
+        }
+    }
+}
+
+// Discord 알림 헬퍼.
+//   pipeline-level `agent none` 이라 post 블록에서 sh 를 직접 실행할 수 없다.
+//   curl 만 들어있는 경량 파드를 띄워 webhook POST 만 수행한다.
+//   webhook URL 은 Jenkins "Secret text" credential(Discord-Webhook) 로 주입되어
+//   Groovy 레벨에는 노출되지 않고 shell env 로만 전달된다. 알림 실패가 파이프라인
+//   결과를 뒤집지 않도록 try/catch 로 감싼다.
+def notifyDiscord(String status) {
+    def color
+    def emoji
+    def text
+    switch (status) {
+        case 'success': color = 3066993;  emoji = ':white_check_mark:'; text = 'Success'; break
+        case 'failure': color = 15158332; emoji = ':x:';                text = 'Failure'; break
+        case 'aborted': color = 15105570; emoji = ':warning:';          text = 'Aborted'; break
+        default:        color = 9807270;  emoji = ':information_source:'; text = status
+    }
+    def jobName   = (env.JOB_NAME   ?: '').toString()
+    def buildNum  = (env.BUILD_NUMBER ?: '').toString()
+    def branch    = (env.BRANCH_NAME ?: '-').toString()
+    def buildUrl  = (env.BUILD_URL  ?: '').toString()
+    def targetEnv = (env.TARGET_ENV ?: '-').toString()
+    def imageTag  = (env.IMAGE_TAG  ?: '-').toString()
+    def duration  = (currentBuild.durationString ?: '-').replace(' and counting', '')
+
+    try {
+        podTemplate(
+            label: "gakhalmo-front-discord-${env.BUILD_NUMBER}",
+            yaml: '''
+apiVersion: v1
+kind: Pod
+spec:
+  containers:
+    - name: curl
+      image: docker.io/curlimages/curl:8.10.1
+      command: ['cat']
+      tty: true
+      resources:
+        requests:
+          cpu: '50m'
+          memory: '64Mi'
+        limits:
+          cpu: '200m'
+          memory: '128Mi'
+'''
+        ) {
+            node(POD_LABEL) {
+                container('curl') {
+                    def payload = groovy.json.JsonOutput.toJson([
+                        username: 'Jenkins',
+                        embeds: [[
+                            title: "${emoji} ${jobName} #${buildNum}".toString(),
+                            url: buildUrl,
+                            color: color,
+                            fields: [
+                                [name: 'Status',   value: text,      inline: true],
+                                [name: 'Branch',   value: branch,    inline: true],
+                                [name: 'Env',      value: targetEnv, inline: true],
+                                [name: 'Image',    value: imageTag,  inline: true],
+                                [name: 'Duration', value: duration,  inline: true]
+                            ]
+                        ]]
+                    ])
+                    writeFile file: 'discord-payload.json', text: payload
+                    withCredentials([string(credentialsId: 'Discord-Webhook', variable: 'DISCORD_WEBHOOK_URL')]) {
+                        sh '''
+                            set +x
+                            curl -sS --max-time 15 --retry 2 --retry-delay 2 \
+                                -o /dev/null -w "discord webhook HTTP %{http_code}\\n" \
+                                -H "Content-Type: application/json" \
+                                -X POST --data-binary @discord-payload.json \
+                                "$DISCORD_WEBHOOK_URL"
+                        '''
+                    }
+                }
+            }
+        }
+    } catch (err) {
+        echo "Discord notification failed: ${err.message}"
     }
 }


### PR DESCRIPTION
## 배경

Jenkins 파이프라인 결과를 실시간으로 공유할 채널이 없어 빌드 실패/성공 여부를 사람이 직접 Jenkins UI 를 열어봐야 하는 상황이었다.

## 변경 사항

`Jenkinsfile` post 블록에 Discord 웹훅 알림을 추가한다.

- `success` / `failure` / `aborted` 세 결과 모두 알림 전송
- webhook URL 은 Jenkins **Secret text** credential `Discord-Webhook` 에서 `withCredentials` 로 shell env 에만 주입 — Groovy/콘솔 평문 노출 차단
- pipeline-level `agent none` 이라 post 블록에서 `sh` 직접 실행이 불가하므로 curl 전용 경량 k8s 파드(`curlimages/curl:8.10.1`, req 50m/64Mi)를 띄워 webhook POST 만 실행
- payload 는 `groovy.json.JsonOutput.toJson` 로 생성 — job / build number / branch / target env / image tag / duration 을 embed 필드로 포함
- 알림 실패(네트워크/rate limit/오입력 webhook 등)가 빌드 결과를 뒤집지 않도록 `try/catch` 로 격리

## 사전 조건

Jenkins 에 다음 credential 이 **Secret text** 로 등록되어야 한다.

- ID: `Discord-Webhook`
- Value: `https://discord.com/api/webhooks/<id>/<token>`

## 검증

- [ ] Jenkins 에서 `Discord-Webhook` credential 등록 확인
- [ ] develop push → 성공 알림 도착 확인
- [ ] 고의 실패 유도 → 실패 알림 도착 확인
- [ ] embed 필드(branch, env, image tag, duration) 정상 표기 확인
- [ ] webhook 오입력 시에도 메인 파이프라인이 정상 종료되는지 확인