### PR TITLE
fix(ci): Discord 알림 POD_LABEL binding 오류 해결

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,9 +122,13 @@ def notifyDiscord(String status) {
     def imageTag  = (env.IMAGE_TAG  ?: '-').toString()
     def duration  = (currentBuild.durationString ?: '-').replace(' and counting', '')
 
+    // podTemplate.label 을 로컬 변수로 바인딩 — kubernetes plugin 버전에 따라
+    // POD_LABEL implicit binding 이 주입되지 않는 경우가 있어 node() 인자는
+    // 반드시 같은 라벨 문자열을 직접 넘긴다.
+    def podLabel = "gakhalmo-front-discord-${env.BUILD_NUMBER}"
     try {
         podTemplate(
-            label: "gakhalmo-front-discord-${env.BUILD_NUMBER}",
+            label: podLabel,
             yaml: '''
 apiVersion: v1
 kind: Pod
@@ -143,7 +147,7 @@ spec:
           memory: '128Mi'
 '''
         ) {
-            node(POD_LABEL) {
+            node(podLabel) {
                 container('curl') {
                     def payload = groovy.json.JsonOutput.toJson([
                         username: 'Jenkins',


### PR DESCRIPTION
## 증상

직전 PR(#30) 머지 후 빌드 결과 알림이 다음 메시지로 실패:

\`\`\`
Discord notification failed: No such property: POD_LABEL for class: groovy.lang.Binding
\`\`\`

파이프라인 본체는 정상 종료되지만 Discord 알림은 전송되지 않음.

## 원인

kubernetes plugin 버전/설정에 따라 \`podTemplate { ... }\` 블록 내부에 \`POD_LABEL\` implicit binding 이 주입되지 않는다. \`node(POD_LABEL)\` 호출부가 해당 binding 을 찾지 못해 \`MissingPropertyException\` 발생 → \`try/catch\` 에 잡혀 알림만 실패한 것.

## 수정

라벨 문자열을 로컬 변수 \`podLabel\` 로 바인딩해 \`podTemplate.label\` 과 \`node()\` 인자에 동일 값을 명시적으로 전달한다. plugin 버전에 의존하지 않는 방식.

## 검증

- [ ] develop push → Jenkins 빌드 성공 알림이 Discord 에 실제 도착
- [ ] 실패 시나리오 → 실패 알림 도착
- [ ] 콘솔 로그에 \`No such property: POD_LABEL\` 메시지가 더이상 나타나지 않음