### PR TITLE
fix(ci): Discord 알림 sh hang 해결 — 이미지를 bitnami/kubectl 로 교체

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,6 +126,9 @@ def notifyDiscord(String status) {
     // POD_LABEL implicit binding 이 주입되지 않는 경우가 있어 node() 인자는
     // 반드시 같은 라벨 문자열을 직접 넘긴다.
     def podLabel = "gakhalmo-front-discord-${env.BUILD_NUMBER}"
+    // 이미지는 bitnami/kubectl(Debian 기반, curl 포함) 을 사용한다.
+    // curlimages/curl 같은 Alpine/busybox 이미지의 /bin/sh 는 durable-task
+    // 의 프로세스 종료 감지와 충돌해 `sh` 스텝이 완료 후에도 hang 된다.
     try {
         podTemplate(
             label: podLabel,
@@ -134,10 +137,12 @@ apiVersion: v1
 kind: Pod
 spec:
   containers:
-    - name: curl
-      image: docker.io/curlimages/curl:8.10.1
+    - name: shell
+      image: docker.io/bitnami/kubectl:latest
       command: ['cat']
       tty: true
+      securityContext:
+        runAsUser: 0
       resources:
         requests:
           cpu: '50m'
@@ -148,7 +153,7 @@ spec:
 '''
         ) {
             node(podLabel) {
-                container('curl') {
+                container('shell') {
                     def payload = groovy.json.JsonOutput.toJson([
                         username: 'Jenkins',
                         embeds: [[


### PR DESCRIPTION
## 증상

직전 PR 머지 후 빌드 결과 — 파이프라인 본체는 **SUCCESS** 로 끝나는데 **post 블록에서 hang**, pipeline timeout 까지 해당 파드가 executor 를 점유. 콘솔 로그 마지막 줄이 `[Pipeline] sh` 에서 멈춤.

## 원인

post 블록의 curl 파드가 `curlimages/curl:8.10.1`(Alpine 기반) 을 사용하는데, Alpine 의 `/bin/sh` 는 busybox. busybox sh 는 Jenkins `durable-task` 플러그인의 프로세스 종료 감지와 충돌해 `curl` 이 정상 종료한 뒤에도 `sh` 스텝이 끝나지 않는다.

실제 curl 은 `--max-time 15` 로 bound 되어 있지만, shell step 자체가 hang 이라 timeout 우회 불가.

## 수정

컨테이너 이미지를 **Debian 기반 `bitnami/kubectl:latest`** 로 교체.

- `/bin/sh` 가 정상 Debian dash 라 durable-task 가 프로세스 종료를 정상 감지
- `curl` 은 `bitnami/minideb` 베이스에 기본 포함
- 컨테이너 이름은 `curl` → `shell` 로 변경해 실제 역할을 드러냄

## 검증

- [ ] develop push → Jenkins 빌드가 정상 시간 내 종료 (hang 없음)
- [ ] Discord 채널에 실제 알림 도착
- [ ] 콘솔 로그에 `discord webhook HTTP 204` 또는 `HTTP 200` 출력 확인
- [ ] 실패 시나리오 → 실패 알림 도착, `[Pipeline] sh` hang 없음